### PR TITLE
Add interface PaymentAddress into WebIDL

### DIFF
--- a/dom/moz.build
+++ b/dom/moz.build
@@ -98,6 +98,7 @@ DIRS += [
     'performance',
     'xhr',
     'worklet',
+    'payments',
 ]
 
 if CONFIG['OS_ARCH'] == 'WINNT':

--- a/dom/payments/PaymentAddress.cpp
+++ b/dom/payments/PaymentAddress.cpp
@@ -1,0 +1,45 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/dom/PaymentAddress.h"
+#include "mozilla/dom/PaymentAddressBinding.h"
+
+namespace mozilla {
+namespace dom {
+
+NS_IMPL_CYCLE_COLLECTION_WRAPPERCACHE(PaymentAddress, mOwner)
+
+NS_IMPL_CYCLE_COLLECTING_ADDREF(PaymentAddress)
+NS_IMPL_CYCLE_COLLECTING_RELEASE(PaymentAddress)
+
+NS_INTERFACE_MAP_BEGIN_CYCLE_COLLECTION(PaymentAddress)
+  NS_WRAPPERCACHE_INTERFACE_MAP_ENTRY
+  NS_INTERFACE_MAP_ENTRY(nsISupports)
+NS_INTERFACE_MAP_END
+
+PaymentAddress::PaymentAddress()
+{
+  // Add |MOZ_COUNT_CTOR(PaymentAddress);| for a non-refcounted object.
+
+  // [TODO]
+  // 1) Set attributes for getter functions
+  // 2) Assign |mOwner| for method |GetParentObject| to return
+}
+
+PaymentAddress::~PaymentAddress()
+{
+  // Add |MOZ_COUNT_DTOR(PaymentAddress);| for a non-refcounted object.
+}
+
+JSObject*
+PaymentAddress::WrapObject(JSContext* aCx, JS::Handle<JSObject*> aGivenProto)
+{
+  return PaymentAddressBinding::Wrap(aCx, this, aGivenProto);
+}
+
+
+} // namespace dom
+} // namespace mozilla

--- a/dom/payments/PaymentAddress.h
+++ b/dom/payments/PaymentAddress.h
@@ -1,0 +1,65 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_dom_PaymentAddress_h
+#define mozilla_dom_PaymentAddress_h
+
+#include "nsPIDOMWindow.h"
+#include "nsWrapperCache.h"
+
+namespace mozilla {
+namespace dom {
+
+class PaymentAddress final : public nsISupports,
+                             public nsWrapperCache
+{
+public:
+  NS_DECL_CYCLE_COLLECTING_ISUPPORTS
+  NS_DECL_CYCLE_COLLECTION_SCRIPT_HOLDER_CLASS(PaymentAddress)
+
+  PaymentAddress();
+
+  nsPIDOMWindowInner* GetParentObject() const
+  {
+    return mOwner;
+  }
+
+  virtual JSObject* WrapObject(JSContext* aCx,
+                               JS::Handle<JSObject*> aGivenProto) override;
+
+  // Getter functions
+  void GetCountry(nsAString& aRetVal) const { }
+
+  void GetAddressLine(nsTArray<nsString>& aRetVal) const { }
+
+  void GetRegion(nsAString& aRetVal) const { }
+
+  void GetCity(nsAString& aRetVal) const { }
+
+  void GetDependentLocality(nsAString& aRetVal) const { }
+
+  void GetPostalCode(nsAString& aRetVal) const { }
+
+  void GetSortingCode(nsAString& aRetVal) const { }
+
+  void GetLanguageCode(nsAString& aRetVal) const { }
+
+  void GetOrganization(nsAString& aRetVal) const { }
+
+  void GetRecipient(nsAString& aRetVal) const { }
+
+  void GetPhone(nsAString& aRetVal) const { }
+
+private:
+  ~PaymentAddress();
+
+  nsCOMPtr<nsPIDOMWindowInner> mOwner;
+};
+
+} // namespace dom
+} // namespace mozilla
+
+#endif // mozilla_dom_PaymentAddress_h

--- a/dom/payments/moz.build
+++ b/dom/payments/moz.build
@@ -1,0 +1,17 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+EXPORTS.mozilla.dom += [
+    'PaymentAddress.h',
+]
+
+UNIFIED_SOURCES += [
+    'PaymentAddress.cpp',
+]
+
+include('/ipc/chromium/chromium-config.mozbuild')
+
+FINAL_LIBRARY = 'xul'

--- a/dom/webidl/PaymentAddress.webidl
+++ b/dom/webidl/PaymentAddress.webidl
@@ -1,0 +1,30 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this WebIDL file is
+ *   https://www.w3.org/TR/payment-request/#paymentaddress-interface
+ */
+
+[SecureContext]
+interface PaymentAddress {
+  // TODO: Use serializer once available. (Bug 863402)
+  // serializer = {attribute};
+  jsonifier;
+
+  readonly attribute DOMString              country;
+  // TODO: Use FrozenArray once available. (Bug 1236777)
+  // readonly attribute FrozenArray<DOMString> addressLine;
+  [Frozen, Cached, Pure]
+  readonly attribute sequence<DOMString>    addressLine;
+  readonly attribute DOMString              region;
+  readonly attribute DOMString              city;
+  readonly attribute DOMString              dependentLocality;
+  readonly attribute DOMString              postalCode;
+  readonly attribute DOMString              sortingCode;
+  readonly attribute DOMString              languageCode;
+  readonly attribute DOMString              organization;
+  readonly attribute DOMString              recipient;
+  readonly attribute DOMString              phone;
+};

--- a/dom/webidl/moz.build
+++ b/dom/webidl/moz.build
@@ -344,6 +344,7 @@ WEBIDL_FILES = [
     'PaintRequestList.webidl',
     'PannerNode.webidl',
     'ParentNode.webidl',
+    'PaymentAddress.webidl',
     'Performance.webidl',
     'PerformanceEntry.webidl',
     'PerformanceMark.webidl',


### PR DESCRIPTION
Add following files:
1. dom/webidl/PaymentAddress.webidl
2. dom/payments/PaymentAddress.{h, cpp}
3. dom/payments/moz.build

Notes:
* PaymentAddress.{h, cpp} are based on files generated from ./mach webidl-example. Prototype only.
* Build pass only, require further verification.