### PR TITLE
Add interface PaymentResponse into WebIDL

### DIFF
--- a/dom/payments/PaymentResponse.cpp
+++ b/dom/payments/PaymentResponse.cpp
@@ -1,0 +1,43 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/dom/PaymentResponse.h"
+
+namespace mozilla {
+namespace dom {
+
+// [TODO] Revisit here once |mShippingAddress| is declared
+NS_IMPL_CYCLE_COLLECTION_WRAPPERCACHE(PaymentResponse, mOwner)
+
+NS_IMPL_CYCLE_COLLECTING_ADDREF(PaymentResponse)
+NS_IMPL_CYCLE_COLLECTING_RELEASE(PaymentResponse)
+
+NS_INTERFACE_MAP_BEGIN_CYCLE_COLLECTION(PaymentResponse)
+  NS_WRAPPERCACHE_INTERFACE_MAP_ENTRY
+  NS_INTERFACE_MAP_ENTRY(nsISupports)
+NS_INTERFACE_MAP_END
+
+PaymentResponse::PaymentResponse()
+{
+  // Add |MOZ_COUNT_CTOR(PaymentResponse);| for a non-refcounted object.
+
+  // [TODO] Assign |mOwner| for method |GetParentObject| to return
+}
+
+PaymentResponse::~PaymentResponse()
+{
+  // Add |MOZ_COUNT_DTOR(PaymentResponse);| for a non-refcounted object.
+}
+
+JSObject*
+PaymentResponse::WrapObject(JSContext* aCx, JS::Handle<JSObject*> aGivenProto)
+{
+  return PaymentResponseBinding::Wrap(aCx, this, aGivenProto);
+}
+
+
+} // namespace dom
+} // namespace mozilla

--- a/dom/payments/PaymentResponse.h
+++ b/dom/payments/PaymentResponse.h
@@ -1,0 +1,75 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_dom_PaymentResponse_h
+#define mozilla_dom_PaymentResponse_h
+
+#include "mozilla/dom/PaymentResponseBinding.h" // PaymentComplete
+#include "nsPIDOMWindow.h"
+#include "nsWrapperCache.h"
+
+namespace mozilla {
+namespace dom {
+
+class PaymentAddress;
+class Promise;
+
+} // namespace dom
+} // namespace mozilla
+
+namespace mozilla {
+namespace dom {
+
+class PaymentResponse final : public nsISupports,
+                              public nsWrapperCache
+{
+public:
+  NS_DECL_CYCLE_COLLECTING_ISUPPORTS
+  NS_DECL_CYCLE_COLLECTION_SCRIPT_HOLDER_CLASS(PaymentResponse)
+
+  PaymentResponse();
+
+  nsPIDOMWindowInner* GetParentObject() const
+  {
+    return mOwner;
+  }
+
+  virtual JSObject* WrapObject(JSContext* aCx,
+                               JS::Handle<JSObject*> aGivenProto) override;
+
+  void GetPaymentRequestID(nsString& aRetVal) const { }
+
+  void GetMethodName(nsString& aRetVal) const { }
+
+  void GetDetails(JSContext* cx, JS::MutableHandle<JSObject*> aRetVal) const { }
+
+  // Return a raw pointer here to avoid refcounting, but make sure it's safe
+  // (the object should be kept alive by the callee).
+  already_AddRefed<PaymentAddress> GetShippingAddress() const { return nullptr; }
+
+  void GetShippingOption(nsString& aRetVal) const { }
+
+  void GetPayerName(nsString& aRetVal) const { }
+
+  void GetPayerEmail(nsString& aRetVal) const { }
+
+  void GetPayerPhone(nsString& aRetVal) const { }
+
+  // Return a raw pointer here to avoid refcounting, but make sure it's safe
+  // (the object should be kept alive by the callee).
+  already_AddRefed<Promise> Complete(PaymentComplete result) { return nullptr; }
+
+protected:
+  ~PaymentResponse();
+
+private:
+  nsCOMPtr<nsPIDOMWindowInner> mOwner;
+};
+
+} // namespace dom
+} // namespace mozilla
+
+#endif // mozilla_dom_PaymentResponse_h

--- a/dom/payments/moz.build
+++ b/dom/payments/moz.build
@@ -6,10 +6,12 @@
 
 EXPORTS.mozilla.dom += [
     'PaymentAddress.h',
+    'PaymentResponse.h'
 ]
 
 UNIFIED_SOURCES += [
     'PaymentAddress.cpp',
+    'PaymentResponse.cpp'
 ]
 
 include('/ipc/chromium/chromium-config.mozbuild')

--- a/dom/webidl/PaymentResponse.webidl
+++ b/dom/webidl/PaymentResponse.webidl
@@ -1,0 +1,32 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this WebIDL file is
+ *   https://www.w3.org/TR/payment-request/#paymentresponse-interface
+ */
+
+enum PaymentComplete {
+  "success",
+  "fail",
+  "unknown"
+};
+
+[SecureContext]
+interface PaymentResponse {
+  // TODO: Use serializer once available. (Bug 863402)
+  // serializer = {attribute};
+  jsonifier;
+
+  readonly attribute DOMString       paymentRequestID;
+  readonly attribute DOMString       methodName;
+  readonly attribute object          details;
+  readonly attribute PaymentAddress? shippingAddress;
+  readonly attribute DOMString?      shippingOption;
+  readonly attribute DOMString?      payerName;
+  readonly attribute DOMString?      payerEmail;
+  readonly attribute DOMString?      payerPhone;
+
+  Promise<void> complete(optional PaymentComplete result = "unknown");
+};

--- a/dom/webidl/moz.build
+++ b/dom/webidl/moz.build
@@ -346,6 +346,7 @@ WEBIDL_FILES = [
     'PannerNode.webidl',
     'ParentNode.webidl',
     'PaymentAddress.webidl',
+    'PaymentResponse.webidl',
     'Performance.webidl',
     'PerformanceEntry.webidl',
     'PerformanceMark.webidl',


### PR DESCRIPTION
Add following files:
1. dom/webidl/PaymentResponse.webidl
2. dom/payments/PaymentResponse.{h, cpp}

Notes:
- PaymentResponse.{h, cpp} are based on files generated from ./mach webidl-example. Prototype only.
- Build pass only, require further verification.
