### PR TITLE
Add interface PaymentRequestUpdateEvent into WebIDL

### DIFF
--- a/dom/payments/PaymentRequestUpdateEvent.cpp
+++ b/dom/payments/PaymentRequestUpdateEvent.cpp
@@ -1,0 +1,40 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/dom/PaymentRequestUpdateEvent.h"
+#include "mozilla/dom/PaymentRequestUpdateEventBinding.h"
+
+namespace mozilla {
+namespace dom {
+
+// [TODO] Revisit here once some member requires cycle collection
+NS_INTERFACE_MAP_BEGIN_CYCLE_COLLECTION_INHERITED(PaymentRequestUpdateEvent)
+NS_INTERFACE_MAP_END_INHERITING(Event)
+
+NS_IMPL_ADDREF_INHERITED(PaymentRequestUpdateEvent, Event)
+NS_IMPL_RELEASE_INHERITED(PaymentRequestUpdateEvent, Event)
+
+PaymentRequestUpdateEvent::PaymentRequestUpdateEvent(EventTarget* aOwner)
+  : Event(aOwner, nullptr, nullptr)
+{
+  // Add |MOZ_COUNT_CTOR(PaymentRequestUpdateEvent);| for a non-refcounted object.
+}
+
+PaymentRequestUpdateEvent::~PaymentRequestUpdateEvent()
+{
+  // Add |MOZ_COUNT_DTOR(PaymentRequestUpdateEvent);| for a non-refcounted object.
+}
+
+JSObject*
+PaymentRequestUpdateEvent::WrapObjectInternal(JSContext* aCx,
+                                              JS::Handle<JSObject*> aGivenProto)
+{
+  return PaymentRequestUpdateEventBinding::Wrap(aCx, this, aGivenProto);
+}
+
+
+} // namespace dom
+} // namespace mozilla

--- a/dom/payments/PaymentRequestUpdateEvent.h
+++ b/dom/payments/PaymentRequestUpdateEvent.h
@@ -1,0 +1,55 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_dom_PaymentRequestUpdateEvent_h
+#define mozilla_dom_PaymentRequestUpdateEvent_h
+
+#include "mozilla/Attributes.h"
+#include "mozilla/ErrorResult.h"
+#include "mozilla/dom/Event.h"
+#include "mozilla/dom/PaymentRequestUpdateEventBinding.h"
+
+namespace mozilla {
+namespace dom {
+
+class Promise;
+
+} // namespace dom
+} // namespace mozilla
+
+namespace mozilla {
+namespace dom {
+
+class PaymentRequestUpdateEvent final : public Event
+{
+public:
+  NS_DECL_ISUPPORTS_INHERITED
+
+  PaymentRequestUpdateEvent(EventTarget* aOwner);
+
+  virtual JSObject*
+    WrapObjectInternal(JSContext* aCx,
+                       JS::Handle<JSObject*> aGivenProto) override;
+
+  static already_AddRefed<PaymentRequestUpdateEvent>
+    Constructor(const GlobalObject& global,
+                const nsAString& type,
+                const PaymentRequestUpdateEventInit& eventInitDict,
+                ErrorResult& aRv)
+  { return nullptr; }
+
+  void UpdateWith(Promise& d) { }
+
+  bool IsTrusted() const { return true; }
+
+protected:
+  ~PaymentRequestUpdateEvent();
+};
+
+} // namespace dom
+} // namespace mozilla
+
+#endif // mozilla_dom_PaymentRequestUpdateEvent_h

--- a/dom/payments/moz.build
+++ b/dom/payments/moz.build
@@ -7,12 +7,14 @@
 EXPORTS.mozilla.dom += [
     'PaymentAddress.h',
     'PaymentRequest.h',
+    'PaymentRequestUpdateEvent.h',
     'PaymentResponse.h',
 ]
 
 UNIFIED_SOURCES += [
     'PaymentAddress.cpp',
     'PaymentRequest.cpp',
+    'PaymentRequestUpdateEvent.cpp',
     'PaymentResponse.cpp',
 ]
 

--- a/dom/webidl/PaymentRequestUpdateEvent.webidl
+++ b/dom/webidl/PaymentRequestUpdateEvent.webidl
@@ -1,0 +1,18 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this WebIDL file is
+ *   https://www.w3.org/TR/payment-request/#paymentrequestupdateevent-interface
+ */
+
+[Constructor(DOMString type,
+             optional PaymentRequestUpdateEventInit eventInitDict),
+ SecureContext]
+interface PaymentRequestUpdateEvent : Event {
+  void updateWith(Promise<PaymentDetails> d);
+};
+
+dictionary PaymentRequestUpdateEventInit : EventInit {
+};

--- a/dom/webidl/moz.build
+++ b/dom/webidl/moz.build
@@ -347,6 +347,7 @@ WEBIDL_FILES = [
     'ParentNode.webidl',
     'PaymentAddress.webidl',
     'PaymentRequest.webidl',
+    'PaymentRequestUpdateEvent.webidl',
     'PaymentResponse.webidl',
     'Performance.webidl',
     'PerformanceEntry.webidl',


### PR DESCRIPTION
Add following files:
1. dom/webidl/PaymentRequestUpdateEvent.webidl
2. dom/payments/PaymentRequestUpdateEvent.{h, cpp}

Notes:
- PaymentRequestUpdateEvent.{h, cpp} are based on files generated from ./mach webidl-example. Prototype only.
- Build pass only, require further verification.
