### PR TITLE
Rename {PaymentRequest, PaymentResponse}.paymetnRequestID to .paymetnRequestId

### DIFF
--- a/dom/payments/PaymentRequest.h
+++ b/dom/payments/PaymentRequest.h
@@ -60,7 +60,7 @@ public:
   // (the object should be kept alive by the callee).
   already_AddRefed<Promise> CanMakePayment() { return nullptr; }
 
-  void GetPaymentRequestID(nsString& aRetVal) const { }
+  void GetPaymentRequestId(nsString& aRetVal) const { }
 
   // Return a raw pointer here to avoid refcounting, but make sure it's safe
   // (the object should be kept alive by the callee).

--- a/dom/payments/PaymentResponse.h
+++ b/dom/payments/PaymentResponse.h
@@ -40,7 +40,7 @@ public:
   virtual JSObject* WrapObject(JSContext* aCx,
                                JS::Handle<JSObject*> aGivenProto) override;
 
-  void GetPaymentRequestID(nsString& aRetVal) const { }
+  void GetPaymentRequestId(nsString& aRetVal) const { }
 
   void GetMethodName(nsString& aRetVal) const { }
 

--- a/dom/webidl/PaymentRequest.webidl
+++ b/dom/webidl/PaymentRequest.webidl
@@ -68,7 +68,7 @@ interface PaymentRequest : EventTarget {
   Promise<void>            abort();
   Promise<boolean>         canMakePayment();
 
-  readonly attribute DOMString?           paymentRequestID;
+  readonly attribute DOMString?           paymentRequestId;
   readonly attribute PaymentAddress?      shippingAddress;
   readonly attribute DOMString?           shippingOption;
   readonly attribute PaymentShippingType? shippingType;

--- a/dom/webidl/PaymentResponse.webidl
+++ b/dom/webidl/PaymentResponse.webidl
@@ -19,7 +19,7 @@ interface PaymentResponse {
   // serializer = {attribute};
   jsonifier;
 
-  readonly attribute DOMString       paymentRequestID;
+  readonly attribute DOMString       paymentRequestId;
   readonly attribute DOMString       methodName;
   readonly attribute object          details;
   readonly attribute PaymentAddress? shippingAddress;


### PR DESCRIPTION
According to w3c/browser-payment-api#414.