### PR TITLE
Revise the way to validate a decimal monetary value

### DIFF
--- a/dom/payments/PaymentRequest.cpp
+++ b/dom/payments/PaymentRequest.cpp
@@ -65,14 +65,34 @@ PaymentRequest::IsValidNumber(const nsAString& aItem,
                               const nsAString& aStr,
                               nsAString& aErrorMsg)
 {
-  nsAutoString aValue(aStr);
-  nsresult error = NS_OK;
-  aValue.ToFloat(&error);
+  nsresult error = NS_ERROR_FAILURE;
+
+  if (!aStr.IsEmpty()) {
+    nsAutoString aValue(aStr);
+
+    // If the beginning character is '-', we will check the second one.
+    int beginningIndex = (aValue.First() == '-') ? 1 : 0;
+
+    // Ensure
+    // - the beginning character is a digit in [0-9], and
+    // - the last character is not '.'
+    // to follow spec:
+    //   https://w3c.github.io/browser-payment-api/#dfn-valid-decimal-monetary-value
+    //
+    // For example, ".1" is not valid for '.' is not in [0-9],
+    // and " 0.1" either for beginning with ' '
+    if (aValue.Last() != '.' &&
+        aValue.CharAt(beginningIndex) >= '0' &&
+        aValue.CharAt(beginningIndex) <= '9') {
+      aValue.ToFloat(&error);
+    }
+  }
+
   if (NS_FAILED(error)) {
     aErrorMsg.AssignLiteral("The amount.value of \"");
     aErrorMsg.Append(aItem);
     aErrorMsg.AppendLiteral("\"(");
-    aErrorMsg.Append(aValue);
+    aErrorMsg.Append(aStr);
     aErrorMsg.AppendLiteral(") must be a valid decimal monetary value.");
     return false;
   }
@@ -80,19 +100,30 @@ PaymentRequest::IsValidNumber(const nsAString& aItem,
 }
 
 bool
-PaymentRequest::IsPositiveNumber(const nsAString& aItem,
-                                 const nsAString& aStr,
-                                 nsAString& aErrorMsg)
+PaymentRequest::IsNonNegativeNumber(const nsAString& aItem,
+                                    const nsAString& aStr,
+                                    nsAString& aErrorMsg)
 {
-  nsAutoString aValue(aStr);
-  nsresult error = NS_OK;
-  float value = aValue.ToFloat(&error);
-  if (NS_FAILED(error) || value < 0) {
+  nsresult error = NS_ERROR_FAILURE;
+
+  if (!aStr.IsEmpty()) {
+    nsAutoString aValue(aStr);
+    // Ensure
+    // - the beginning character is a digit in [0-9], and
+    // - the last character is not '.'
+    if (aValue.Last() != '.' &&
+        aValue.First() >= '0' &&
+        aValue.First() <= '9') {
+      aValue.ToFloat(&error);
+    }
+  }
+
+  if (NS_FAILED(error)) {
     aErrorMsg.AssignLiteral("The amount.value of \"");
     aErrorMsg.Append(aItem);
     aErrorMsg.AppendLiteral("\"(");
-    aErrorMsg.Append(aValue);
-    aErrorMsg.AppendLiteral(") must be a valid and positive decimal monetary value.");
+    aErrorMsg.Append(aStr);
+    aErrorMsg.AppendLiteral(") must be a valid and non-negative decimal monetary value.");
     return false;
   }
   return true;
@@ -102,8 +133,8 @@ bool
 PaymentRequest::IsValidDetailsInit(const PaymentDetailsInit& aDetails, nsAString& aErrorMsg)
 {
   // Check the amount.value of detail.total
-  if (!IsPositiveNumber(NS_LITERAL_STRING("details.total"),
-                        aDetails.mTotal.mAmount.mValue, aErrorMsg)) {
+  if (!IsNonNegativeNumber(NS_LITERAL_STRING("details.total"),
+                           aDetails.mTotal.mAmount.mValue, aErrorMsg)) {
     return false;
   }
 
@@ -115,8 +146,8 @@ PaymentRequest::IsValidDetailsUpdate(const PaymentDetailsUpdate& aDetails)
 {
   nsString message;
   // Check the amount.value of detail.total
-  if (!IsPositiveNumber(NS_LITERAL_STRING("details.total"),
-                        aDetails.mTotal.mAmount.mValue, message)) {
+  if (!IsNonNegativeNumber(NS_LITERAL_STRING("details.total"),
+                           aDetails.mTotal.mAmount.mValue, message)) {
     return false;
   }
 
@@ -152,8 +183,8 @@ PaymentRequest::IsValidDetailsBase(const PaymentDetailsBase& aDetails, nsAString
   if (aDetails.mModifiers.WasPassed()) {
     const Sequence<PaymentDetailsModifier>& modifiers = aDetails.mModifiers.Value();
     for (const PaymentDetailsModifier& modifier : modifiers) {
-      if (!IsPositiveNumber(NS_LITERAL_STRING("details.modifiers.total"),
-                            modifier.mTotal.mAmount.mValue, aErrorMsg)) {
+      if (!IsNonNegativeNumber(NS_LITERAL_STRING("details.modifiers.total"),
+                               modifier.mTotal.mAmount.mValue, aErrorMsg)) {
         return false;
       }
       if (modifier.mAdditionalDisplayItems.WasPassed()) {

--- a/dom/payments/PaymentRequest.h
+++ b/dom/payments/PaymentRequest.h
@@ -52,9 +52,9 @@ public:
                   const nsAString& aStr,
                   nsAString& aErrorMsg);
   static bool
-    IsPositiveNumber(const nsAString& aItem,
-                     const nsAString& aStr,
-                     nsAString& aErrorMsg);
+    IsNonNegativeNumber(const nsAString& aItem,
+                        const nsAString& aStr,
+                        nsAString& aErrorMsg);
 
   static bool
     IsValidDetailsInit(const PaymentDetailsInit& aDetails, nsAString& aErrorMsg);


### PR DESCRIPTION
We need to do the validation by the following definition.

A JavaScript string is a valid decimal monetary value if it consists of the following code points in the given order:    
Optionally, a single U+002D HYPHEN-MINUS (-), to indicate that the amount is negative.
One or more code points in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9).
Optionally, a single U+002E FULL STOP (.) followed by one or more code points in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9).